### PR TITLE
Adding crd-requirements.txt to the contants.py file and fixing error message typo

### DIFF
--- a/mlt/utils/constants.py
+++ b/mlt/utils/constants.py
@@ -30,3 +30,6 @@ TEMPLATE_CONFIG = "parameters.json"
 
 # Name of config file section that has template parameters
 TEMPLATE_PARAMETERS = "template_parameters"
+
+# Name of the file that list required CRDs
+CRD_CHECK_FILE = "crd-requirements.txt"

--- a/mlt/utils/kubernetes_helpers.py
+++ b/mlt/utils/kubernetes_helpers.py
@@ -24,7 +24,7 @@ import json
 
 from subprocess import call
 
-from mlt.utils import process_helpers
+from mlt.utils import constants, process_helpers
 
 
 def ensure_namespace_exists(ns):
@@ -36,9 +36,9 @@ def ensure_namespace_exists(ns):
 
 def check_crds(exit_on_failure=False, app_name=None):
     if app_name is None:
-        crd_file = 'crd-requirements.txt'
+        crd_file = constants.CRD_CHECK_FILE
     else:
-        crd_file = os.path.join(app_name, 'crd-requirements.txt')
+        crd_file = os.path.join(app_name, constants.CRD_CHECK_FILE)
     if os.path.exists(crd_file):
         with open(crd_file) as f:
             # using f.read().splitlines() instead of f.readlines()
@@ -60,7 +60,8 @@ def check_crds(exit_on_failure=False, app_name=None):
             if exit_on_failure:
                 sys.exit(1)
     else:
-        print('file does not exits: {}'.format(crd_file))
+        print("Skipping CRD check, because the '{}' file does not exist.".
+              format(crd_file))
 
 
 def checking_crds_on_k8(crd_set):

--- a/tests/unit/utils/test_kubernetes_helpers.py
+++ b/tests/unit/utils/test_kubernetes_helpers.py
@@ -21,7 +21,8 @@
 import uuid
 from mock import patch
 
-from mlt.utils.kubernetes_helpers import ensure_namespace_exists
+from mlt.utils.kubernetes_helpers import check_crds, ensure_namespace_exists
+from test_utils.io import catch_stdout
 
 
 @patch('mlt.utils.kubernetes_helpers.call')
@@ -42,3 +43,12 @@ def test_ensure_namespace_already_exists(proc_helpers, open_mock, call):
 
     ensure_namespace_exists(str(uuid.uuid4()))
     proc_helpers.run.assert_called_once()
+
+
+def test_crd_check_file_does_not_exist():
+    with catch_stdout() as caught_output:
+        check_crds(False, "foo")
+        output = caught_output.getvalue().lower()
+
+    assert "skipping crd check" in output
+    assert "does not exist" in output


### PR DESCRIPTION
Added `crd-requirements.txt` to the `constants.py` file and fixing typo in the error message (it was `exits` instead of `exists`).


## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.
