### PR TITLE
Adding CRD check file for the `tf-dist-mnist` template

### DIFF
--- a/mlt-templates/tf-dist-mnist/crd-requirements.txt
+++ b/mlt-templates/tf-dist-mnist/crd-requirements.txt
@@ -1,0 +1,1 @@
+tfjobs.kubeflow.org


### PR DESCRIPTION
Noticed that the `tf-dist-mnist` template doesn't have a `crd-requirements.txt` file and this template requires the TFJob CRD.


## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.
