### PR TITLE
Updates docs to use 'Templates' instead of 'Tool'

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-Machine Learning Container Tool
+Machine Learning Container Templates
 Copyright (c) 2018 Intel Corporation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mlt
-Machine Learning Container Tool
+Machine Learning Container Templates
 
 > MLT: it's like the keras of kubernetes
 >

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@
 from setuptools import setup, find_packages
 
 setup(name='mlt',
-      description='Machine Learning Container Tool',
+      description='Machine Learning Container Templates',
       long_description=open('README.md').read(),
       author='Intel Nervana',
       author_email='intelnervana@intel.com',


### PR DESCRIPTION
fixes #184 

Updates documentation to use the name "Machine Learning Container Templates" instead of "Machine Learning Container Tool".


## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.
