### PR TITLE
Fix for issue #175 (specify namespace when doing kubectl exec for interactive mode)

### DIFF
--- a/mlt/commands/deploy.py
+++ b/mlt/commands/deploy.py
@@ -294,5 +294,5 @@ class DeployCommand(Command):
             time.sleep(1)
 
         process_helpers.run_popen(
-            ["kubectl", "exec", "-it", podname,
+            ["kubectl", "exec", "-it", podname, "--namespace", self.namespace,
              "/bin/bash"], stdout=None, stderr=None).wait()


### PR DESCRIPTION
fixes #175

Added `--namespace` to the kubectl exec command for mlt deploy in interactive mode.  This fixes the use case where the user is using a namespace other than their default namespace.

## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.
