### PR TITLE
Add mlt config command and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,26 @@ $ mlt init my-app --template=hello-world
 
 $ cd my-app
 
-# Optional step: Modify parameters in the mlt.json file
-$ vim mlt.json
+# List the config parameters
+$ mlt config list
+Parameter Name                Value
+----------------------------  ----------------------
+gceProject                    my-project-12345
+namespace                     my-app
+name                          my-app
+template_parameters.greeting  Hello
+
+# Update the greeting parameter
+$ mlt config set template_parameters.greeting Hi
+
+# Check the config list to see the updated parameter value
+$ mlt config list
+Parameter Name                Value
+----------------------------  ----------------------
+gceProject                    constant-cubist-173123
+namespace                     dmsuehir
+name                          dmsuehir
+template_parameters.greeting  Hi
 
 $ mlt build
 Starting build my-app:71fb176d-28a9-46c2-ab51-fe3d4a88b02c
@@ -122,7 +140,7 @@ Skipping image push
 Deploying localhost:5000/test:d6c9c06b-2b64-4038-a6a9-434bf90d6acc
 
 Inspect created objects by running:
-$ kubectl get --namespace=robertso all
+$ kubectl get --namespace=my-app all
 
 Connecting to pod...
 root@test-9e035719-1d8b-4e0c-adcb-f706429ffeac-wl42v:/src/app# ls

--- a/mlt/commands/__init__.py
+++ b/mlt/commands/__init__.py
@@ -20,6 +20,7 @@
 
 from mlt.commands.base import Command  # noqa
 from mlt.commands.build import BuildCommand  # noqa
+from mlt.commands.config import ConfigCommand  # noqa
 from mlt.commands.deploy import DeployCommand  # noqa
 from mlt.commands.init import InitCommand  # noqa
 from mlt.commands.status import StatusCommand  # noqa

--- a/mlt/commands/config.py
+++ b/mlt/commands/config.py
@@ -1,0 +1,123 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software`
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+import sys
+from tabulate import tabulate
+
+from mlt.commands import Command
+from mlt.utils import config_helpers, constants
+
+
+class ConfigCommand(Command):
+    def __init__(self, args):
+        super(ConfigCommand, self).__init__(args)
+        self.list = args.get('list', False)
+        self.set = args.get('set', False)
+        self.unset = args.get('unset', False)
+        self.name = args.get('<name>', None)
+        self.value = args.get('<value>', None)
+        self.config = config_helpers.load_config()
+
+        self.param_keys = self.name.split('.') if self.name else None
+
+        if (self.set or self.unset) and not self.name:
+            print("Name of the configuration parameter must be specified.")
+            sys.exit(1)
+
+    def action(self):
+        # Call the specified sub-command
+        if self.list:
+            print("list")
+            self._list_configs()
+        elif self.set:
+            print("set")
+            self._set_config()
+        elif self.unset:
+            print("unset")
+            self._unset_config()
+        else:
+            print("Invalid config command.  Must have one of the following"
+                  "sub-command selected: list, set, unset.")
+            sys.exit(1)
+
+    def _list_configs(self):
+        """
+        Lists the config parameters and their values using tabulate.
+        """
+        config_list = []
+        for config_name in self.config.keys():
+            if config_name == constants.TEMPLATE_PARAMETERS:
+                template_params = self.config[config_name]
+                for template_config in template_params.keys():
+                    config_list.append(["{}.{}".format(
+                        constants.TEMPLATE_PARAMETERS, template_config),
+                        template_params[template_config]])
+            else:
+                config_list.append([config_name, self.config[config_name]])
+
+        if len(config_list) > 0:
+            print(tabulate(config_list, headers=['App Config', 'Value']))
+        else:
+            print("No configuration parameters to display.")
+
+    def _set_config(self):
+        """
+        Sets the config parameter to the specified value.  If the config
+        parameter does not already exist in the MLT config, then it's added.
+        Writes the new config back to the mlt config file.
+        """
+        # Find or add the specified config
+        matched_config = self.config
+        for n in self.param_keys[:-1]:
+            if n in matched_config:
+                matched_config = matched_config[n]
+            else:
+                matched_config[n] = {}
+
+        # Set the config value then write it back to the config file.
+        matched_config[self.param_keys[-1]] = self.value
+        config_helpers.update_config(self.config)
+
+    def _unset_config(self):
+        """
+        Finds, then removes the specified config parameter from the MLT config
+        file.  If the config parameter does not exist in the MLT config file,
+        then an error is displayed.
+        """
+        matched_config = self.config
+        key_not_found = "Unable to find config '{}'.\nTo see " \
+                        "list of configs, use `mlt config list`.". \
+            format(self.name)
+
+        # Find the specified config, and display an error if it does not exist.
+        for n in self.param_keys[:-1]:
+            if n in matched_config:
+                matched_config = matched_config[n]
+            else:
+                print(key_not_found)
+                sys.exit(1)
+
+        # Delete the config parameter and then write it back to the config file
+        if self.param_keys[-1] in matched_config:
+            del matched_config[self.param_keys[-1]]
+        else:
+            print(key_not_found)
+            sys.exit(1)
+        config_helpers.update_config(self.config)

--- a/mlt/commands/config.py
+++ b/mlt/commands/config.py
@@ -38,8 +38,8 @@ class ConfigCommand(Command):
             self._list_configs()
         elif self.args.get('set'):
             self._set_config(self.param_keys, self.args.get('<value>'))
-        elif self.args.get('unset'):
-            self._unset_config(self.param_keys)
+        elif self.args.get('remove'):
+            self._remove_config(self.param_keys)
 
     def _list_configs(self):
         """
@@ -94,13 +94,12 @@ class ConfigCommand(Command):
         matched_config[param_keys[-1]] = value
         config_helpers.update_config(self.config)
 
-    def _unset_config(self, param_keys):
+    def _remove_config(self, param_keys):
         """
         Finds, then removes the specified config parameter from the MLT config
         file.  If the config parameter does not exist in the MLT config file,
         then an error is displayed.
         """
-        matched_config = self.config
         key_not_found = "Unable to find config '{}'. To see " \
                         "list of configs, use `mlt config list`.". \
             format(self.args.get('<name>'))

--- a/mlt/main.py
+++ b/mlt/main.py
@@ -25,7 +25,7 @@ Usage:
   mlt init [--template=<template> --template-repo=<repo>]
       [--registry=<registry> --namespace=<namespace]
       [--skip-crd-check] <name>
-  mlt config (list | set <name> <value> | unset <name>)
+  mlt config (list | set <name> <value> | remove <name>)
   mlt build [--watch]
   mlt deploy [--no-push] [-i | --interactive]
       [--retries=<retries>] [--skip-crd-check] [<kube_spec>]
@@ -128,7 +128,7 @@ def sanitize_input(args, regex=None):
                              args['--namespace']))
 
     # Set and Unset config commands require the name arg
-    if (args.get('set') or args.get('unset')) and not args.get('<name>'):
+    if (args.get('set') or args.get('remove')) and not args.get('<name>'):
         raise ValueError("Name of the configuration parameter must be "
                          "specified.")
 

--- a/mlt/main.py
+++ b/mlt/main.py
@@ -100,7 +100,7 @@ def sanitize_input(args, regex=None):
        It is recommended on docopt github to do validation
     """
     # docker requires repo name to be in lowercase
-    if args["<name>"] and args.get("init", None):
+    if args["<name>"] and args.get("init"):
         args["<name>"] = args["<name>"].lower()
 
         if not regex_checks.k8s_name_is_valid(args["<name>"], "pod"):
@@ -126,6 +126,11 @@ def sanitize_input(args, regex=None):
                          "https://kubernetes.io/docs/concepts/overview"
                          "/working-with-objects/names/#names".format(
                              args['--namespace']))
+
+    # Set and Unset config commands require the name arg
+    if (args.get('set') or args.get('unset')) and not args.get('<name>'):
+        raise ValueError("Name of the configuration parameter must be "
+                         "specified.")
 
     return args
 

--- a/mlt/main.py
+++ b/mlt/main.py
@@ -25,6 +25,7 @@ Usage:
   mlt init [--template=<template> --template-repo=<repo>]
       [--registry=<registry> --namespace=<namespace]
       [--skip-crd-check] <name>
+  mlt config (list | set <name> <value> | unset <name>)
   mlt build [--watch]
   mlt deploy [--no-push] [-i | --interactive]
       [--retries=<retries>] [--skip-crd-check] [<kube_spec>]
@@ -63,13 +64,15 @@ import mlt
 
 from docopt import docopt
 
-from mlt.commands import (BuildCommand, DeployCommand, InitCommand,
-                          StatusCommand, TemplatesCommand, UndeployCommand)
+from mlt.commands import (BuildCommand, ConfigCommand, DeployCommand,
+                          InitCommand, StatusCommand, TemplatesCommand,
+                          UndeployCommand)
 from mlt.utils import regex_checks
 
 # every available command and its corresponding action will go here
 COMMAND_MAP = (
     ('build', BuildCommand),
+    ('config', ConfigCommand),
     ('deploy', DeployCommand),
     ('init', InitCommand),
     ('status', StatusCommand),
@@ -97,7 +100,7 @@ def sanitize_input(args, regex=None):
        It is recommended on docopt github to do validation
     """
     # docker requires repo name to be in lowercase
-    if args["<name>"]:
+    if args["<name>"] and args.get("init", None):
         args["<name>"] = args["<name>"].lower()
 
         if not regex_checks.k8s_name_is_valid(args["<name>"], "pod"):

--- a/mlt/utils/config_helpers.py
+++ b/mlt/utils/config_helpers.py
@@ -35,6 +35,12 @@ def load_config():
         sys.exit(1)
 
 
+def update_config(json_data):
+    """overwrites the existing MLT config with the specified data"""
+    with open(constants.MLT_CONFIG, "w") as f:
+        json.dump(json_data, f, indent=2)
+
+
 def get_template_parameters_from_file(file_path):
     """ Returns template parameters from the specified file """
     params = {}

--- a/tests/e2e/test_config_updates.py
+++ b/tests/e2e/test_config_updates.py
@@ -64,7 +64,7 @@ def test_update_config():
 def test_add_remove_config():
     """
     Tests adding a new config, and then lists the configs to ensure that the
-    new config is listed.  Unsets the config and then lists the configs to 
+    new config is listed.  Remove the config and then lists the configs to 
     ensure that the config has been removed.
     """
     with create_work_dir() as workdir:
@@ -86,8 +86,8 @@ def test_add_remove_config():
         p = re.compile("{}[\s]+{}".format(new_config, new_value))
         assert p.search(str(updated_configs))
 
-        # unset the config and then ensure that the config has been removed.
-        commands.config(subcommand="unset", config_name=new_config)
+        # remove the config and then ensure that the config has been removed.
+        commands.config(subcommand="remove", config_name=new_config)
         updated_configs, _ = commands.config(subcommand="list")
         p = re.compile("{}[\s]+{}".format(new_config, new_value))
         assert not p.search(str(updated_configs))

--- a/tests/e2e/test_config_updates.py
+++ b/tests/e2e/test_config_updates.py
@@ -1,0 +1,93 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+import re
+
+from test_utils.e2e_commands import CommandTester
+from test_utils.files import create_work_dir
+
+
+# NOTE: you need to deploy first before you deploy with --no-push
+# otherwise you have no image to use to make new container from
+
+
+def test_config_list():
+    """
+    Tests listing configs in an init directory
+    """
+    with create_work_dir() as workdir:
+        commands = CommandTester(workdir)
+        commands.init()
+        commands.config(subcommand="list")
+
+
+def test_update_config():
+    """
+    Tests the `name` config and then checks the config list to ensure that
+    the new `name` is listed.
+    """
+    with create_work_dir() as workdir:
+        commands = CommandTester(workdir)
+        commands.init()
+
+        # list the configs
+        original_configs, _ = commands.config(subcommand="list")
+
+        # set the `name` config to `foo`
+        new_name = "foo"
+        commands.config(subcommand="set", config_name="name",
+                        config_value=new_name)
+
+        # list the configs again and compare to ensure the `name` was updated.
+        updated_configs, _ = commands.config(subcommand="list")
+        assert updated_configs != original_configs
+        p = re.compile("name[\s]+{}".format(new_name))
+        assert p.search(str(updated_configs))
+
+
+def test_add_remove_config():
+    """
+    Tests adding a new config, and then lists the configs to ensure that the
+    new config is listed.  Unsets the config and then lists the configs to 
+    ensure that the config has been removed.
+    """
+    with create_work_dir() as workdir:
+        commands = CommandTester(workdir)
+        commands.init()
+
+        # list the configs
+        original_configs, _ = commands.config(subcommand="list")
+
+        # add a new config named `foo`
+        new_config = "foo"
+        new_value = "bar"
+        commands.config(subcommand="set", config_name=new_config,
+                        config_value=new_value)
+
+        # list the configs again to ensure that the new config is added.
+        updated_configs, _ = commands.config(subcommand="list")
+        assert updated_configs != original_configs
+        p = re.compile("{}[\s]+{}".format(new_config, new_value))
+        assert p.search(str(updated_configs))
+
+        # unset the config and then ensure that the config has been removed.
+        commands.config(subcommand="unset", config_name=new_config)
+        updated_configs, _ = commands.config(subcommand="list")
+        p = re.compile("{}[\s]+{}".format(new_config, new_value))
+        assert not p.search(str(updated_configs))

--- a/tests/e2e/test_deploy_flow.py
+++ b/tests/e2e/test_deploy_flow.py
@@ -27,6 +27,7 @@ from test_utils.files import create_work_dir
 # NOTE: you need to deploy first before you deploy with --no-push
 # otherwise you have no image to use to make new container from
 
+
 @pytest.mark.parametrize('template',
                          filter(lambda x: os.path.isdir(
                              os.path.join('mlt-templates', x)),

--- a/tests/e2e/test_deploy_flow.py
+++ b/tests/e2e/test_deploy_flow.py
@@ -27,7 +27,6 @@ from test_utils.files import create_work_dir
 # NOTE: you need to deploy first before you deploy with --no-push
 # otherwise you have no image to use to make new container from
 
-
 @pytest.mark.parametrize('template',
                          filter(lambda x: os.path.isdir(
                              os.path.join('mlt-templates', x)),

--- a/tests/test_utils/e2e_commands.py
+++ b/tests/test_utils/e2e_commands.py
@@ -27,7 +27,7 @@ import json
 import os
 import time
 import uuid
-from subprocess import PIPE, Popen
+from subprocess import check_output, PIPE, Popen
 
 from mlt.utils.process_helpers import run, run_popen
 from project import basedir
@@ -81,6 +81,25 @@ class CommandTester(object):
         assert "On branch master" in run(
             "git --git-dir={}/.git --work-tree={} status".format(
                 self.project_dir, self.project_dir).split())
+
+    def config(self, subcommand="list", config_name=None, config_value=None):
+        command = ['mlt', 'config', subcommand]
+
+        if config_name:
+            command.append(config_name)
+
+        if config_value:
+            command.append(config_value)
+
+        p = Popen(command, cwd=self.project_dir, stdout=PIPE)
+        output, err = p.communicate()
+        assert p.wait() == 0
+
+        if subcommand == "list":
+            assert output
+
+        assert err is None
+        return output, err
 
     def build(self, watch=False):
         build_cmd = ['mlt', 'build']

--- a/tests/unit/commands/test_config.py
+++ b/tests/unit/commands/test_config.py
@@ -1,0 +1,290 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+from __future__ import print_function
+
+import pytest
+import re
+
+from test_utils.io import catch_stdout
+
+from mlt.commands.config import ConfigCommand
+from mlt.utils import constants
+
+
+@pytest.fixture
+def init_mock(patch):
+    return patch('config_helpers.load_config')
+
+
+@pytest.fixture
+def update_config_mock(patch):
+    return patch('config_helpers.update_config')
+
+
+def config(list=False, set=False, unset=False, name=None, value=None):
+    config_cmd = ConfigCommand({"list": list, "set": set, "unset": unset,
+                                "<name>": name, "<value>": value})
+
+    with catch_stdout() as caught_output:
+        config_cmd.action()
+        output = caught_output.getvalue()
+    return output
+
+
+def test_uninitialized_config_call():
+    """
+    Tests calling the config command before the app has been initialized.
+    """
+    with catch_stdout() as caught_output:
+        with pytest.raises(SystemExit):
+            ConfigCommand({})
+        output = caught_output.getvalue()
+        expected_error = "This command requires you to be in an `mlt init` " \
+                         "built directory"
+        assert expected_error in output
+
+
+def test_invalid_subcommand(init_mock):
+    """
+    Tests calling the config command without a valid subcommand
+    """
+    init_mock.load_config.return_value = {}
+    with catch_stdout() as caught_output:
+        with pytest.raises(SystemExit):
+            cmd = ConfigCommand({"list": False, "set": False, "unset": False})
+            cmd.action()
+        output = caught_output.getvalue()
+        assert "Invalid config command" in output
+
+
+@pytest.mark.parametrize("set_param, unset_param, name_param", [
+    (True, False, None),
+    (True, False, ""),
+    (False, True, None),
+    (False, True, "")
+])
+def test_no_parameter(init_mock, set_param, unset_param, name_param):
+    """
+    Tests that both the set and unset commands require the name arg
+    """
+    expected_error = "Name of the configuration parameter must be specified"
+    with catch_stdout() as caught_output:
+        with pytest.raises(SystemExit):
+            config(set=set_param, unset=unset_param, name=name_param)
+        output = caught_output.getvalue()
+        assert expected_error in output
+
+
+def test_list_config(init_mock):
+    """
+    Test calling the config list command and checks the output.
+    """
+    init_mock.return_value = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    output = config(list=True)
+
+    p = re.compile("namespace[\s]+foo")
+    assert p.search(output)
+    p = re.compile("registry[\s]+bar")
+    assert p.search(output)
+    p = re.compile("{}.num_workers[\s]+2".format(
+        constants.TEMPLATE_PARAMETERS))
+    assert p.search(output)
+
+
+def test_list_empty_configs(init_mock):
+    """
+    Tests calling the config list command when there are no configs. 
+    """
+    init_mock.return_value = {}
+    output = config(list=True)
+    assert "No configuration parameters to display." in output
+
+
+def test_set_existing_config(init_mock, update_config_mock):
+    """
+    Tests modifying an existing config parameter
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+    modified_parameter = "namespace"
+    new_value = "new-namespace"
+    config(set=True, name=modified_parameter, value=new_value)
+    mlt_config[modified_parameter] = new_value
+    update_config_mock.assert_called_with(mlt_config)
+
+
+def test_set_new_config(init_mock, update_config_mock):
+    """
+    Tests setting a new config parameter, and ensures that the parameter is
+    added to the config file.
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+    new_parameter = "new_parameter"
+    new_value = "new_value"
+    config(set=True, name=new_parameter, value=new_value)
+    mlt_config[new_parameter] = new_value
+    update_config_mock.assert_called_with(mlt_config)
+
+
+def test_set_existing_template_parameter(init_mock, update_config_mock):
+    """
+    Tests modifying an existing template parameter
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+    modified_parameter = "{}.num_workers".format(constants.TEMPLATE_PARAMETERS)
+    new_value = 4
+    config(set=True, name=modified_parameter, value=new_value)
+    mlt_config[constants.TEMPLATE_PARAMETERS][modified_parameter] = new_value
+    update_config_mock.assert_called_with(mlt_config)
+
+
+def test_set_unset_new_template_parameter(init_mock, update_config_mock):
+    """
+    Tests setting a new template parameter, ensures that the parameter is
+    added to the config file, then unsets the parameter.
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+
+    # Set new template parameter
+    new_parameter = "{}.num_ps".format(constants.TEMPLATE_PARAMETERS)
+    new_value = 1
+    config(set=True, name=new_parameter, value=new_value)
+
+    # Check that the config update was called with the new parameter
+    expected_parameter = mlt_config
+    expected_parameter[constants.TEMPLATE_PARAMETERS][new_parameter] = \
+        new_value
+    update_config_mock.assert_called_with(expected_parameter)
+
+    # Unset the parameter, and we should be back to the original
+    config(unset=True, name=new_parameter)
+    update_config_mock.assert_called_with(mlt_config)
+
+
+def test_set_unset_new_parameter(init_mock, update_config_mock):
+    """
+    Tests setting and unsetting a new parameter a few levels deep.
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+
+    # Set new parameter
+    new_parameter = "foo1.foo2.foo3"
+    new_value = "new_value"
+    config(set=True, name=new_parameter, value=new_value)
+
+    # check that the config update was called with the new parameter
+    expected_config = mlt_config
+    expected_config["foo1"] = {}
+    expected_config["foo1"]["foo2"] = {}
+    expected_config["foo1"]["foo2"]["foo3"] = new_value
+    update_config_mock.assert_called_with(expected_config)
+
+    # Unset the parameter and check that we are back to the original config
+    config(unset=True, name=new_parameter)
+    update_config_mock.assert_called_with(mlt_config)
+
+
+def test_unset_config_param(init_mock, update_config_mock):
+    """
+    Tests removing an existing config
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+
+    # Unset the registry parameter and check the config update arg
+    config(unset=True, name="registry")
+    expected_config = {
+        "namespace": "foo",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    update_config_mock.assert_called_with(expected_config)
+
+
+@pytest.mark.parametrize("param_name", [
+    "does-not-exist",
+    "{}.does-not-exist".format(constants.TEMPLATE_PARAMETERS),
+    "subparam.does-not-exist"
+])
+def test_unset_invalid_param(init_mock, param_name):
+    """
+    Tests trying to remove a parameter that does not exist
+    """
+    mlt_config = {
+        "namespace": "foo",
+        "registry": "bar",
+        constants.TEMPLATE_PARAMETERS: {
+            "num_workers": 2
+        }
+    }
+    init_mock.return_value = mlt_config
+
+    # Unset the registry parameter and check the config update arg
+    with pytest.raises(SystemExit):
+        output = config(unset=True, name=param_name)
+        assert "Unable to find config" in output

--- a/tests/unit/commands/test_config.py
+++ b/tests/unit/commands/test_config.py
@@ -62,37 +62,6 @@ def test_uninitialized_config_call():
         assert expected_error in output
 
 
-def test_invalid_subcommand(init_mock):
-    """
-    Tests calling the config command without a valid subcommand
-    """
-    init_mock.load_config.return_value = {}
-    with catch_stdout() as caught_output:
-        with pytest.raises(SystemExit):
-            cmd = ConfigCommand({"list": False, "set": False, "unset": False})
-            cmd.action()
-        output = caught_output.getvalue()
-        assert "Invalid config command" in output
-
-
-@pytest.mark.parametrize("set_param, unset_param, name_param", [
-    (True, False, None),
-    (True, False, ""),
-    (False, True, None),
-    (False, True, "")
-])
-def test_no_parameter(init_mock, set_param, unset_param, name_param):
-    """
-    Tests that both the set and unset commands require the name arg
-    """
-    expected_error = "Name of the configuration parameter must be specified"
-    with catch_stdout() as caught_output:
-        with pytest.raises(SystemExit):
-            config(set=set_param, unset=unset_param, name=name_param)
-        output = caught_output.getvalue()
-        assert expected_error in output
-
-
 def test_list_config(init_mock):
     """
     Test calling the config list command and checks the output.

--- a/tests/unit/commands/test_config.py
+++ b/tests/unit/commands/test_config.py
@@ -39,8 +39,8 @@ def update_config_mock(patch):
     return patch('config_helpers.update_config')
 
 
-def config(list=False, set=False, unset=False, name=None, value=None):
-    config_cmd = ConfigCommand({"list": list, "set": set, "unset": unset,
+def config(list=False, set=False, remove=False, name=None, value=None):
+    config_cmd = ConfigCommand({"list": list, "set": set, "remove": remove,
                                 "<name>": name, "<value>": value})
 
     with catch_stdout() as caught_output:
@@ -151,10 +151,10 @@ def test_set_existing_template_parameter(init_mock, update_config_mock):
     update_config_mock.assert_called_with(mlt_config)
 
 
-def test_set_unset_new_template_parameter(init_mock, update_config_mock):
+def test_set_remove_new_template_parameter(init_mock, update_config_mock):
     """
     Tests setting a new template parameter, ensures that the parameter is
-    added to the config file, then unsets the parameter.
+    added to the config file, then removes the parameter.
     """
     mlt_config = {
         "namespace": "foo",
@@ -176,14 +176,14 @@ def test_set_unset_new_template_parameter(init_mock, update_config_mock):
         new_value
     update_config_mock.assert_called_with(expected_parameter)
 
-    # Unset the parameter, and we should be back to the original
-    config(unset=True, name=new_parameter)
+    # Remove the parameter, and we should be back to the original
+    config(remove=True, name=new_parameter)
     update_config_mock.assert_called_with(mlt_config)
 
 
-def test_set_unset_new_parameter(init_mock, update_config_mock):
+def test_set_remove_new_parameter(init_mock, update_config_mock):
     """
-    Tests setting and unsetting a new parameter a few levels deep.
+    Tests setting and removing a new parameter a few levels deep.
     """
     mlt_config = {
         "namespace": "foo",
@@ -206,12 +206,12 @@ def test_set_unset_new_parameter(init_mock, update_config_mock):
     expected_config["foo1"]["foo2"]["foo3"] = new_value
     update_config_mock.assert_called_with(expected_config)
 
-    # Unset the parameter and check that we are back to the original config
-    config(unset=True, name=new_parameter)
+    # Remove the parameter and check that we are back to the original config
+    config(remove=True, name=new_parameter)
     update_config_mock.assert_called_with(mlt_config)
 
 
-def test_unset_config_param(init_mock, update_config_mock):
+def test_remove_config_param(init_mock, update_config_mock):
     """
     Tests removing an existing config
     """
@@ -224,8 +224,8 @@ def test_unset_config_param(init_mock, update_config_mock):
     }
     init_mock.return_value = mlt_config
 
-    # Unset the registry parameter and check the config update arg
-    config(unset=True, name="registry")
+    # Remove the registry parameter and check the config update arg
+    config(remove=True, name="registry")
     expected_config = {
         "namespace": "foo",
         constants.TEMPLATE_PARAMETERS: {
@@ -240,7 +240,7 @@ def test_unset_config_param(init_mock, update_config_mock):
     "{}.does-not-exist".format(constants.TEMPLATE_PARAMETERS),
     "subparam.does-not-exist"
 ])
-def test_unset_invalid_param(init_mock, param_name):
+def test_remove_invalid_param(init_mock, param_name):
     """
     Tests trying to remove a parameter that does not exist
     """
@@ -253,7 +253,7 @@ def test_unset_invalid_param(init_mock, param_name):
     }
     init_mock.return_value = mlt_config
 
-    # Unset the registry parameter and check the config update arg
+    # Remove the registry parameter and check the config update arg
     with pytest.raises(SystemExit):
-        output = config(unset=True, name=param_name)
+        output = config(remove=True, name=param_name)
         assert "Unable to find config" in output

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -89,10 +89,10 @@ def test_main_invalid_namespace(docopt_mock):
 
 @pytest.mark.parametrize("command", [
     "set",
-    "unset"
+    "remove"
 ])
 @patch('mlt.main.docopt')
-def test_main_set_unset_name(docopt_mock, command):
+def test_main_set_remove_name(docopt_mock, command):
     """ Ensure that set and unset commands require name arg."""
     args = {
         command: True,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -86,3 +86,22 @@ def test_main_invalid_namespace(docopt_mock):
     with pytest.raises(ValueError):
         main()
         run_command(args)
+
+@pytest.mark.parametrize("command", [
+    "set",
+    "unset"
+])
+@patch('mlt.main.docopt')
+def test_main_set_unset_name(docopt_mock, command):
+    """ Ensure that set and unset commands require name arg."""
+    args = {
+        command: True,
+        "--namespace": "foo",
+        "<name>": "",
+        "-i": False,
+        "--retries": 5
+    }
+    docopt_mock.return_value = args
+    with pytest.raises(ValueError):
+        main()
+        run_command(args)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -62,7 +62,8 @@ def test_main_various_args(run_command, docopt, args):
 def test_main_invalid_names(docopt_mock):
     """ Test that an invalid name throws a ValueError """
     args = {
-        # underscore should not be allowed in name
+        # underscore should not be allowed in name for the init command
+        "init": True,
         "<name>": "foo_bar"
     }
     docopt_mock.return_value = args


### PR DESCRIPTION
fixes #129

Add `mlt config` command (with subcommands: list, set, remove) to allow users to view and modify values in the `mlt.json` file.

## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.
