### PR TITLE
Fix working with local template repos (issue #154)

### DIFF
--- a/mlt/commands/templates.py
+++ b/mlt/commands/templates.py
@@ -34,8 +34,7 @@ class TemplatesCommand(Command):
             templates_directory = os.path.join(temp_clone, TEMPLATES_DIR)
             templates = self._parse_templates(templates_directory)
             if not templates:
-                if template_repo.startswith("git@") or \
-                   template_repo.startswith("https://"):
+                if git_helpers.is_git_repo(template_repo):
                     print("Please verify git is installed and setup "
                           "properly and you have read access to the repo.")
                 else:

--- a/mlt/utils/git_helpers.py
+++ b/mlt/utils/git_helpers.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from distutils.dir_util import copy_tree
 
 from mlt.utils import process_helpers
 
@@ -32,6 +33,12 @@ def clone_repo(repo):
     process_helpers.run_popen(
         "git clone {} {}".format(repo, destination),
         shell=True, stdout=False, stderr=False).wait()
+
+    # If the template repo is a local path, then copy the local directory over
+    # the git clone so that the templates reflect the local changes.
+    if not is_git_repo(repo):
+        copy_tree(repo, destination)
+
     try:
         yield destination
     finally:
@@ -39,3 +46,9 @@ def clone_repo(repo):
         # https://bugs.python.org/issue29699
         if os.path.exists(destination):
             shutil.rmtree(destination)
+
+
+def is_git_repo(template_repo):
+    """ Returns True if the template_repo looks like a git repository. """
+    return template_repo.startswith("git@") or \
+        template_repo.startswith("https://")

--- a/tests/e2e/test_templates.py
+++ b/tests/e2e/test_templates.py
@@ -27,10 +27,14 @@ from test_utils.e2e_commands import CommandTester
 from test_utils.files import create_work_dir
 
 
+def call_template_list(template_repo):
+    return check_output(['mlt', 'templates', 'list',
+                         '--template-repo={}'.format(template_repo)]
+                        ).decode("utf-8")
+
+
 def test_templates():
-    output = check_output(['mlt', 'templates', 'list',
-                           '--template-repo={}'.format(project.basedir())]
-                          ).decode("utf-8")
+    output = call_template_list(project.basedir())
     desired_template_output = """Template             Description
 -------------------  --------------------------------------------------------------------------------------------------
 hello-world          A TensorFlow python HelloWorld example run through Kubernetes Jobs.
@@ -60,9 +64,7 @@ def test_local_templates():
             f.write("New local template for testing")
 
         # call mlt template list and then check the output
-        output = check_output(['mlt', 'templates', 'list',
-                               '--template-repo={}'.format(temp_clone)]
-                              ).decode("utf-8")
+        output = call_template_list(temp_clone)
 
         # template list should include our new test-local template
         desired_template_output = """Template             Description

--- a/tests/e2e/test_templates.py
+++ b/tests/e2e/test_templates.py
@@ -18,8 +18,13 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+import os
 from subprocess import check_output
 from test_utils import project
+
+from mlt.utils import constants, git_helpers
+from test_utils.e2e_commands import CommandTester
+from test_utils.files import create_work_dir
 
 
 def test_templates():
@@ -35,3 +40,46 @@ tf-dist-mnist        A distributed TensorFlow MNIST model which designates worke
 tf-distributed       A distributed TensorFlow matrix multiplication run through the TensorFlow Kubernetes Operator.
 """
     assert output == desired_template_output
+
+
+def test_local_templates():
+    """ Tests creating a new template in a clone of mlt.  Verifies that we can
+    specify the template-repo for mlt template list and see the new template in
+    the list.  Then uses mlt init to create an app with our new template and
+    verifies that the app directory exists. """
+    # Create a git clone of mlt to use as a local template diretory
+    with git_helpers.clone_repo(project.basedir()) as temp_clone:
+        # Add a new test template to the local mlt template directory
+        templates_directory = os.path.join(temp_clone, constants.TEMPLATES_DIR)
+        new_template_name = "test-local"
+        new_template_directory = os.path.join(templates_directory,
+                                              new_template_name)
+        os.mkdir(new_template_directory)
+        new_template_file = os.path.join(new_template_directory, "README.md")
+        with open(new_template_file, "w") as f:
+            f.write("New local template for testing")
+
+        # call mlt template list and then check the output
+        output = check_output(['mlt', 'templates', 'list',
+                               '--template-repo={}'.format(temp_clone)]
+                              ).decode("utf-8")
+
+        # template list should include our new test-local template
+        desired_template_output = """Template             Description
+-------------------  --------------------------------------------------------------------------------------------------
+hello-world          A TensorFlow python HelloWorld example run through Kubernetes Jobs.
+pytorch              Sample distributed application taken from http://pytorch.org/tutorials/intermediate/dist_tuto.html
+pytorch-distributed  A distributed PyTorch MNIST example run using the pytorch-operator.
+test-local           New local template for testing
+tf-dist-mnist        A distributed TensorFlow MNIST model which designates worker 0 as the chief.
+tf-distributed       A distributed TensorFlow matrix multiplication run through the TensorFlow Kubernetes Operator.
+"""
+        assert output == desired_template_output
+
+        # init an app with this new template and verify that the app exists
+        with create_work_dir() as workdir:
+            commands = CommandTester(workdir)
+            commands.init(template=new_template_name, template_repo=temp_clone)
+            app_directory = os.path.join(workdir, commands.app_name)
+            assert os.path.isdir(app_directory)
+            assert os.path.isfile(os.path.join(app_directory, "README.md"))

--- a/tests/test_utils/e2e_commands.py
+++ b/tests/test_utils/e2e_commands.py
@@ -60,10 +60,10 @@ class CommandTester(object):
             catalog_call = 'curl --noproxy \"*\"  registry:5000/v2/_catalog'
         return catalog_call
 
-    def init(self, template='hello-world'):
+    def init(self, template='hello-world', template_repo=basedir()):
         p = Popen(
             ['mlt', 'init', '--registry={}'.format(self.registry),
-             '--template-repo={}'.format(basedir()),
+             '--template-repo={}'.format(template_repo),
              '--namespace={}'.format(self.namespace),
              '--template={}'.format(template), self.app_name],
             cwd=self.workdir)

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -47,6 +47,11 @@ def copytree_mock(patch):
 
 
 @pytest.fixture
+def copy_tree_mock(patch):
+    return patch('git_helpers.copy_tree')
+
+
+@pytest.fixture
 def process_helpers(patch):
     return patch('process_helpers')
 
@@ -85,7 +90,7 @@ def test_init_dir_exists():
 
 
 def test_init(open_mock, process_helpers, copytree_mock, check_output_mock,
-              config_helpers_mock):
+              config_helpers_mock, copy_tree_mock):
     check_output_mock.return_value.decode.return_value = 'bar'
     new_dir = str(uuid.uuid4())
 
@@ -104,7 +109,8 @@ def test_init(open_mock, process_helpers, copytree_mock, check_output_mock,
     assert init.app_name == new_dir
 
 
-def test_init_crd_check(checking_crds_mock, process_helpers, check_output_mock):
+def test_init_crd_check(checking_crds_mock, process_helpers, check_output_mock,
+                        copy_tree_mock):
     new_dir = str(uuid.uuid4())
     init_dict = {
         'init': True,

--- a/tests/unit/commands/test_templates.py
+++ b/tests/unit/commands/test_templates.py
@@ -27,12 +27,17 @@ from test_utils import project
 from test_utils.io import catch_stdout
 
 
+@pytest.fixture
+def copy_tree_mock(patch):
+    return patch('git_helpers.copy_tree')
+
+
 @pytest.mark.parametrize("valid_template_dir", [
     project.basedir(),
     "git@github.com:IntelAI/mlt.git",
     "https://github.com/IntelAI/mlt",
 ])
-def test_template_list(valid_template_dir):
+def test_template_list(valid_template_dir, copy_tree_mock):
     args = {
         'template': 'test',
         'list': True,
@@ -48,7 +53,7 @@ def test_template_list(valid_template_dir):
     "git@github.com:1ntelA1/mlt.git",
     "https://github.com/1ntelA1/mlt",
 ])
-def test_template_list_invalid_repo_dir(invalid_template_dir):
+def test_template_list_invalid_repo_dir(invalid_template_dir, copy_tree_mock):
     invalid_template_dir = "/tmp/invalid-mlt-dir"
     args = {
         'template': 'test',

--- a/tests/unit/utils/test_git_helpers.py
+++ b/tests/unit/utils/test_git_helpers.py
@@ -1,0 +1,34 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+import pytest
+from mock import patch, MagicMock
+
+from mlt.utils import git_helpers
+
+
+@pytest.mark.parametrize("template_repo,is_git", [
+    ("git@github.com:IntelAI/mlt.git", True),
+    ("https://github.com/IntelAI/mlt.git", True),
+    (".", False),
+    ("/home/user/mlt", False)
+])
+def test_is_git_repo(template_repo, is_git):
+    assert git_helpers.is_git_repo(template_repo) == is_git


### PR DESCRIPTION
fixes #154

When the `--template-repo` is not a git repo, copy the local repo over the git clone so that we don't lose any uncommitted files.  This is done in `git_helpers.clone_repo` and is used for both `mlt template list` and `mlt init`.

## Reviewer Checklist

 - [ ] Do you understand it?
 - [ ] Is it correct?
 - [ ] Is it safe?
 - [ ] Is it legally compliant?
 - [ ] Is it robust?
 - [ ] Is it simple?
 - [ ] Is it tested?
 - [ ] Is it documented?
 - [ ] Is the style consistent?

See [the reviewer guide](docs/reviews.md) for more detail on each check.